### PR TITLE
Remove bundled textures and reference remote samples

### DIFF
--- a/docs/composables/index.md
+++ b/docs/composables/index.md
@@ -1,0 +1,82 @@
+# Composables
+
+vhree.js exposes a typed Composition API layer mirroring the underlying Three.js objects. Each helper returns a `shallowRef` pointing at the lazily created instance plus a disposer to eagerly release GPU resources when you are done. The helpers never hide the Three.js objects from you—mutating them directly remains the recommended approach.
+
+## Core accessors
+
+| Hook | Description |
+| ---- | ----------- |
+| `useVhree()` | Inject the nearest `<Vhree>` provider. Useful when a composable needs access to the shared scene, renderer, or render loop. |
+| `useRenderLoop()` | Obtain the shared render loop handle exposed by `<Vhree>`. You can subscribe via `useFrame` or call `loop.step()` manually in headless contexts. |
+| `useCamera(options)` | Lazily create a `PerspectiveCamera`. When a provider is present the camera can register itself as the active camera; pass `{ active: false }` to opt out. |
+| `useScene(options)` | Resolve the provider’s `THREE.Scene`. Set `createLocal: true` to spin up a standalone scene when working outside `<Vhree>`. |
+
+## Geometry helpers
+
+| Hook | Notes |
+| ---- | ----- |
+| `useBoxGeometry(options)` | Generates a parametrised `BoxGeometry`. Previous instances are disposed when options change. |
+| `useSphereGeometry(options)` | Equivalent helper for `SphereGeometry` with the usual latitude/longitude controls. |
+
+## Materials and lighting
+
+| Hook | Notes |
+| ---- | ----- |
+| `useStandardMaterial(options)` | Creates a `MeshStandardMaterial` and mutates it in-place as options change. Supports colour, emissive, roughness/metalness, and texture bindings. |
+| `useDirectionalLight(options)` | Instantiates a `DirectionalLight`, adds it to the active scene, and keeps transforms, intensity, and shadow settings reactive. |
+
+## Controls
+
+`useOrbitControls(options)` lazily imports `OrbitControls`, wiring it to the current camera and renderer. Damping and auto-rotation automatically subscribe to the shared render loop so the control updates run exactly when needed. The hook exposes the raw `OrbitControls` instance through a `shallowRef` plus an `isActive` computed flag.
+
+```ts
+import { ref } from 'vue'
+import { useOrbitControls } from 'vhree.js'
+
+const enableDamping = ref(true)
+const { controls, isActive } = useOrbitControls(() => ({
+  enableDamping: enableDamping.value,
+  dampingFactor: 0.1,
+  autoRotate: false,
+}))
+```
+
+## Loader utilities
+
+All loader helpers expose the same contract: `resource` (`texture`/`envMap`/`gltf`), `isLoading`, `error`, `reload()`, and `dispose()`. They cancel obsolete requests, dispose superseded textures or scenes, and remain SSR-safe by short-circuiting when no `window` is available.
+
+| Hook | Highlights |
+| ---- | ---------- |
+| `useTexture(source, options)` | Wraps `THREE.TextureLoader`, exposes loading state, and supports colour space, filtering, mipmap, and wrapping configuration. |
+| `useEnvMap(source, options)` | Loads cube or equirectangular sources, optionally processes them through `PMREMGenerator`, and reuses the renderer from context when available. |
+| `useGLTF(url, options)` | Loads `.gltf`/`.glb` assets, enabling DRACO, KTX2, or Meshopt decoders on demand. Previous scenes, geometries, and materials are disposed before the new asset is exposed, and failures include the requested URL for clarity. |
+
+Example texture binding:
+
+```ts
+import * as THREE from 'three'
+import { ref, watchEffect } from 'vue'
+import { useTexture } from 'vhree.js'
+
+const source = ref('https://threejs.org/examples/textures/uv_grid_opengl.jpg')
+const { texture, isLoading, error, reload } = useTexture(source, {
+  colorSpace: THREE.SRGBColorSpace,
+  generateMipmaps: true,
+})
+
+watchEffect(() => {
+  if (error.value)
+    console.error('Texture load failed', error.value)
+})
+```
+
+## Types
+
+The `src/types/common.ts` module centralises shared tuples and helper types:
+
+- `Vec3` — `[number, number, number]` tuples used for positions, targets, and scales.
+- `EulerTuple` — `[number, number, number, EulerOrder?]` tuples for rotations.
+- `ColorLike` — alias to `THREE.ColorRepresentation` used across props and composables.
+- `Disposable` — function signature for cleanup handlers returned by composables.
+
+Re-exported via `vhree.js`, these types help keep application code precise without importing Three.js internals in multiple places.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ hero:
     - theme: alt
       text: Learn about VMesh
       link: /components/vmesh
+    - theme: alt
+      text: Explore composables
+      link: /composables/
 
 features:
   - title: SSR by default

--- a/src/composables/controls/useOrbitControls.ts
+++ b/src/composables/controls/useOrbitControls.ts
@@ -1,0 +1,198 @@
+import * as THREE from 'three'
+import type { MaybeRefOrGetter, ShallowRef, WatchStopHandle, ComputedRef } from 'vue'
+import { computed, onBeforeUnmount, shallowRef, watch } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { Disposable, Vec3 } from '../../types/common'
+import { useVhree } from '../core/useVhree'
+import { useFrame } from '../useFrame'
+
+const isClient = typeof window !== 'undefined'
+
+interface OrbitControlsCtor {
+  new (camera: THREE.Camera, domElement: HTMLElement): OrbitControlsInstance
+}
+
+interface OrbitControlsInstance {
+  object: THREE.Camera
+  domElement: HTMLElement
+  target: THREE.Vector3
+  enableDamping: boolean
+  dampingFactor: number
+  autoRotate: boolean
+  autoRotateSpeed: number
+  enableZoom: boolean
+  minDistance: number
+  maxDistance: number
+  enablePan: boolean
+  dispose: () => void
+  update: () => void
+}
+
+type OrbitControlsModule = typeof import('three/examples/jsm/controls/OrbitControls')
+
+let ctorPromise: Promise<OrbitControlsCtor> | null = null
+
+async function resolveCtor(): Promise<OrbitControlsCtor> {
+  if (ctorPromise)
+    return ctorPromise
+  ctorPromise = import('three/examples/jsm/controls/OrbitControls').then((mod: OrbitControlsModule) => mod.OrbitControls)
+  return ctorPromise
+}
+
+export interface UseOrbitControlsOptions {
+  target?: Vec3
+  enableDamping?: boolean
+  dampingFactor?: number
+  autoRotate?: boolean
+  autoRotateSpeed?: number
+  enableZoom?: boolean
+  minDistance?: number
+  maxDistance?: number
+  enablePan?: boolean
+}
+
+export interface UseOrbitControlsResult {
+  controls: ShallowRef<OrbitControlsInstance | null>
+  dispose: Disposable
+  isActive: ComputedRef<boolean>
+}
+
+function applyVector(target: THREE.Vector3, tuple?: Vec3) {
+  if (!tuple)
+    return
+  target.set(tuple[0], tuple[1], tuple[2])
+}
+
+/**
+ * Attach `OrbitControls` to the active camera/renderer pair provided by <Vhree>.
+ */
+export function useOrbitControls(options?: MaybeRefOrGetter<UseOrbitControlsOptions | undefined>): UseOrbitControlsResult {
+  const { context } = useVhree()
+  const controls: ShallowRef<OrbitControlsInstance | null> = shallowRef(null)
+  let frameStop: Disposable | null = null
+  let stopWatch: WatchStopHandle | null = null
+  let disposed = false
+  let lastToken = 0
+
+  const disposeControls = () => {
+    frameStop?.()
+    frameStop = null
+    controls.value?.dispose()
+    controls.value = null
+  }
+
+  const dispose: Disposable = () => {
+    disposed = true
+    stopWatch?.()
+    stopWatch = null
+    disposeControls()
+  }
+
+  const ensureFrameSubscription = () => {
+    const instance = controls.value
+    const shouldTick = !!instance && (instance.enableDamping || instance.autoRotate)
+    if (shouldTick) {
+      if (!frameStop)
+        frameStop = useFrame(() => controls.value?.update())
+    }
+    else if (frameStop) {
+      frameStop()
+      frameStop = null
+    }
+  }
+
+  if (!isClient) {
+    if (import.meta.env.DEV) {
+      console.warn('[vhree] useOrbitControls() is a client-only composable. The call will be a no-op during SSR.')
+    }
+    return {
+      controls,
+      dispose,
+      isActive: computed(() => false),
+    }
+  }
+
+  const applyOptions = () => {
+    const instance = controls.value
+    if (!instance)
+      return
+
+    const next = options ? toValue(options) ?? {} : {}
+
+    if (next.target)
+      applyVector(instance.target, next.target)
+    instance.enableDamping = next.enableDamping ?? instance.enableDamping
+    if (typeof next.dampingFactor === 'number')
+      instance.dampingFactor = next.dampingFactor
+    instance.autoRotate = next.autoRotate ?? instance.autoRotate
+    if (typeof next.autoRotateSpeed === 'number')
+      instance.autoRotateSpeed = next.autoRotateSpeed
+    if (typeof next.enableZoom === 'boolean')
+      instance.enableZoom = next.enableZoom
+    if (typeof next.enablePan === 'boolean')
+      instance.enablePan = next.enablePan
+    if (typeof next.minDistance === 'number')
+      instance.minDistance = next.minDistance
+    if (typeof next.maxDistance === 'number')
+      instance.maxDistance = next.maxDistance
+
+    instance.update()
+    ensureFrameSubscription()
+  }
+
+  const setupWatch = () => {
+    stopWatch = watch(
+      () => {
+        const value = context.value
+        return [value?.camera.value ?? null, value?.renderer.value ?? null] as const
+      },
+      ([camera, renderer]) => {
+        if (!camera || !renderer) {
+          disposeControls()
+          return
+        }
+
+        const canvas = renderer.domElement
+        if (!canvas) {
+          disposeControls()
+          return
+        }
+
+        const token = ++lastToken
+        resolveCtor()
+          .then((Ctor) => {
+            if (disposed || token !== lastToken)
+              return
+
+            disposeControls()
+            const instance = new Ctor(camera, canvas)
+            controls.value = instance
+            applyOptions()
+          })
+          .catch((error) => {
+            if (import.meta.env.DEV)
+              console.warn('[vhree] Failed to instantiate OrbitControls.', error)
+          })
+      },
+      { immediate: true },
+    )
+  }
+
+  setupWatch()
+
+  watch(
+    () => (options ? toValue(options) : undefined),
+    () => applyOptions(),
+    { deep: true },
+  )
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return {
+    controls,
+    dispose,
+    isActive: computed(() => !!controls.value),
+  }
+}

--- a/src/composables/core/useCamera.ts
+++ b/src/composables/core/useCamera.ts
@@ -1,0 +1,157 @@
+import * as THREE from 'three'
+import { onBeforeUnmount, shallowRef, watchEffect } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { Disposable, Vec3 } from '../../types/common'
+import type { VhreeContextValue } from '../../core/context'
+import { useVhree } from './useVhree'
+
+export interface UseCameraOptions {
+  fov?: number
+  near?: number
+  far?: number
+  position?: Vec3
+  up?: Vec3
+  lookAt?: Vec3 | null
+  active?: boolean
+}
+
+export interface UseCameraResult {
+  camera: ShallowRef<THREE.PerspectiveCamera | null>
+  dispose: Disposable
+}
+
+const DEFAULT_POSITION: Vec3 = [0, 0, 5]
+const DEFAULT_UP: Vec3 = [0, 1, 0]
+
+/**
+ * Create a managed `PerspectiveCamera` that optionally registers itself with the nearest <Vhree> provider.
+ */
+export function useCamera(options?: MaybeRefOrGetter<UseCameraOptions | undefined>): UseCameraResult {
+  const { context } = useVhree()
+  const camera: ShallowRef<THREE.PerspectiveCamera | null> = shallowRef(null)
+  const positionVec = new THREE.Vector3()
+  const upVec = new THREE.Vector3()
+  const lookAtVec = new THREE.Vector3()
+
+  let lastFov: number | null = null
+  let lastNear: number | null = null
+  let lastFar: number | null = null
+  let owner: symbol | null = null
+  let active = false
+  let boundContext: VhreeContextValue | null = null
+
+  const ensureCamera = (opts: UseCameraOptions): THREE.PerspectiveCamera => {
+    if (!camera.value) {
+      const fov = typeof opts.fov === 'number' ? opts.fov : 60
+      const near = typeof opts.near === 'number' ? opts.near : 0.1
+      const far = typeof opts.far === 'number' ? opts.far : 100
+      const instance = new THREE.PerspectiveCamera(fov, 1, near, far)
+      const pos = opts.position ?? DEFAULT_POSITION
+      instance.position.set(pos[0], pos[1], pos[2])
+      const up = opts.up ?? DEFAULT_UP
+      instance.up.set(up[0], up[1], up[2])
+      camera.value = instance
+      lastFov = fov
+      lastNear = near
+      lastFar = far
+    }
+    return camera.value
+  }
+
+  const dispose: Disposable = () => {
+    const ctx = boundContext
+    if (ctx && camera.value && owner) {
+      ctx.releaseCamera({ owner, camera: camera.value, dispose: false })
+      active = false
+    }
+    camera.value?.dispose?.()
+    camera.value = null
+    owner = null
+    boundContext = null
+  }
+
+  watchEffect(() => {
+    const opts = options ? toValue(options) ?? {} : {}
+    const instance = ensureCamera(opts)
+
+    let needsProjectionUpdate = false
+    if (typeof opts.fov === 'number' && opts.fov !== lastFov) {
+      instance.fov = opts.fov
+      lastFov = opts.fov
+      needsProjectionUpdate = true
+    }
+
+    if (typeof opts.near === 'number' && opts.near !== lastNear) {
+      instance.near = Math.max(0.0001, opts.near)
+      lastNear = instance.near
+      needsProjectionUpdate = true
+    }
+
+    if (typeof opts.far === 'number' && opts.far !== lastFar) {
+      instance.far = Math.max(instance.near + 0.0001, opts.far)
+      lastFar = instance.far
+      needsProjectionUpdate = true
+    }
+
+    const nextPosition = opts.position ?? DEFAULT_POSITION
+    positionVec.set(nextPosition[0], nextPosition[1], nextPosition[2])
+    if (!positionVec.equals(instance.position))
+      instance.position.copy(positionVec)
+
+    const nextUp = opts.up ?? DEFAULT_UP
+    upVec.set(nextUp[0], nextUp[1], nextUp[2])
+    if (!upVec.equals(instance.up))
+      instance.up.copy(upVec)
+
+    if (opts.lookAt) {
+      lookAtVec.set(opts.lookAt[0], opts.lookAt[1], opts.lookAt[2])
+      instance.lookAt(lookAtVec)
+    }
+
+    if (needsProjectionUpdate)
+      instance.updateProjectionMatrix()
+  })
+
+  watchEffect((onCleanup) => {
+    const ctx = context.value
+    const opts = options ? toValue(options) ?? {} : {}
+    const instance = camera.value
+    if (!ctx || !instance)
+      return
+
+    if (ctx !== boundContext) {
+      if (boundContext && owner && active)
+        boundContext.releaseCamera({ owner, camera: instance, dispose: false })
+      owner = ctx.registerCameraOwner()
+      boundContext = ctx
+      active = false
+    }
+
+    if (!owner)
+      owner = ctx.registerCameraOwner()
+
+    const shouldBeActive = opts.active !== false
+    if (shouldBeActive && !active) {
+      ctx.setCamera(instance, { owner: owner!, disposePrev: false })
+      active = true
+    }
+    else if (!shouldBeActive && active) {
+      ctx.releaseCamera({ owner: owner!, camera: instance, dispose: false })
+      active = false
+    }
+
+    onCleanup(() => {
+      if (active && boundContext && owner && camera.value) {
+        boundContext.releaseCamera({ owner, camera: camera.value, dispose: false })
+        active = false
+      }
+    })
+  })
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return { camera, dispose }
+}

--- a/src/composables/core/useRenderLoop.ts
+++ b/src/composables/core/useRenderLoop.ts
@@ -1,0 +1,19 @@
+import { computed } from 'vue'
+import type { ComputedRef } from 'vue'
+import type { RenderLoop } from '../../core/loop'
+import { useVhree } from './useVhree'
+
+export interface UseRenderLoopResult {
+  loop: ComputedRef<RenderLoop | null>
+}
+
+/**
+ * Expose the shared render loop created by <Vhree>. Consumers can subscribe via `useFrame` or call `step` manually.
+ */
+export function useRenderLoop(): UseRenderLoopResult {
+  const { context } = useVhree()
+
+  return {
+    loop: computed(() => context.value?.loop ?? null),
+  }
+}

--- a/src/composables/core/useVhree.ts
+++ b/src/composables/core/useVhree.ts
@@ -1,0 +1,24 @@
+import { computed, inject } from 'vue'
+import type { ComputedRef } from 'vue'
+import { VHREE_CTX } from '../../core/context'
+import type { VhreeContextValue } from '../../core/context'
+
+export interface UseVhreeResult {
+  /** Reactive access to the shared vhree.js context. */
+  context: ComputedRef<VhreeContextValue | null>
+}
+
+/**
+ * Access the nearest <Vhree> provider. Returns a computed context reference so consumers can react to provider swaps.
+ */
+export function useVhree(): UseVhreeResult {
+  const ctx = inject(VHREE_CTX, null)
+
+  if (!ctx && import.meta.env.DEV) {
+    console.warn('[vhree] useVhree() requires a <Vhree> provider in the component hierarchy.')
+  }
+
+  return {
+    context: computed(() => ctx),
+  }
+}

--- a/src/composables/geom/useBoxGeometry.ts
+++ b/src/composables/geom/useBoxGeometry.ts
@@ -1,0 +1,84 @@
+import * as THREE from 'three'
+import { onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef, WatchStopHandle } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { Disposable } from '../../types/common'
+
+export interface UseBoxGeometryOptions {
+  width?: number
+  height?: number
+  depth?: number
+  widthSegments?: number
+  heightSegments?: number
+  depthSegments?: number
+}
+
+export interface UseBoxGeometryResult {
+  geometry: ShallowRef<THREE.BoxGeometry | null>
+  dispose: Disposable
+}
+
+function createGeometry(options: UseBoxGeometryOptions): THREE.BoxGeometry {
+  const {
+    width = 1,
+    height = 1,
+    depth = 1,
+    widthSegments = 1,
+    heightSegments = 1,
+    depthSegments = 1,
+  } = options
+
+  return new THREE.BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
+}
+
+/**
+ * Lazily instantiate a `THREE.BoxGeometry` that updates whenever the options change.
+ */
+export function useBoxGeometry(options?: MaybeRefOrGetter<UseBoxGeometryOptions | undefined>): UseBoxGeometryResult {
+  const geometry: ShallowRef<THREE.BoxGeometry | null> = shallowRef(null)
+  let stop: WatchStopHandle | null = null
+
+  const dispose: Disposable = () => {
+    stop?.()
+    stop = null
+    if (geometry.value) {
+      geometry.value.dispose()
+      geometry.value = null
+    }
+  }
+
+  const apply = (next: UseBoxGeometryOptions | undefined) => {
+    const resolved = next ?? {}
+    const fresh = createGeometry(resolved)
+    const previous = geometry.value
+    geometry.value = fresh
+    previous?.dispose()
+  }
+
+  if (options) {
+    let lastSignature = ''
+    stop = watch(
+      () => {
+        const value = toValue(options) ?? {}
+        return `${value.width ?? 1}|${value.height ?? 1}|${value.depth ?? 1}|${value.widthSegments ?? 1}|${value.heightSegments ?? 1}|${value.depthSegments ?? 1}`
+      },
+      (signature) => {
+        if (signature === lastSignature)
+          return
+        lastSignature = signature
+        const resolved = toValue(options) ?? {}
+        apply(resolved)
+      },
+      { immediate: true },
+    )
+  }
+  else {
+    apply(undefined)
+  }
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return { geometry, dispose }
+}

--- a/src/composables/geom/useScene.ts
+++ b/src/composables/geom/useScene.ts
@@ -1,0 +1,75 @@
+import * as THREE from 'three'
+import { computed, shallowRef, onBeforeUnmount } from 'vue'
+import type { ShallowRef, ComputedRef } from 'vue'
+import type { Disposable } from '../../types/common'
+import { useVhree } from '../core/useVhree'
+
+export interface UseSceneOptions {
+  /** When true, create a standalone scene if no provider is available. */
+  createLocal?: boolean
+  /** Optional callback executed exactly once when a local scene gets created. */
+  onCreate?: (scene: THREE.Scene) => void
+}
+
+export interface UseSceneResult {
+  scene: ComputedRef<THREE.Scene | null>
+  dispose: Disposable
+}
+
+/**
+ * Access the shared scene created by <Vhree>. When no provider is found and `createLocal` is enabled,
+ * the composable will lazily instantiate a standalone `THREE.Scene` that gets disposed on unmount.
+ */
+export function useScene(options: UseSceneOptions = {}): UseSceneResult {
+  const { context } = useVhree()
+  const localScene: ShallowRef<THREE.Scene | null> = shallowRef(null)
+
+  const ensureLocalScene = (): THREE.Scene => {
+    if (!localScene.value) {
+      localScene.value = new THREE.Scene()
+      options.onCreate?.(localScene.value)
+    }
+    return localScene.value
+  }
+
+  const scene = computed(() => {
+    const existing = context.value?.scene.value
+    if (existing)
+      return existing
+    if (options.createLocal)
+      return ensureLocalScene()
+    return null
+  })
+
+  const dispose: Disposable = () => {
+    if (!localScene.value)
+      return
+    try {
+      localScene.value.traverse((child) => {
+        const mesh = child as THREE.Mesh
+        if (mesh.isMesh) {
+          if (Array.isArray(mesh.material)) {
+            mesh.material.forEach((material) => material.dispose?.())
+          }
+          else {
+            mesh.material?.dispose?.()
+          }
+          mesh.geometry?.dispose?.()
+        }
+      })
+    }
+    finally {
+      localScene.value.clear()
+      localScene.value = null
+    }
+  }
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return {
+    scene,
+    dispose,
+  }
+}

--- a/src/composables/geom/useSphereGeometry.ts
+++ b/src/composables/geom/useSphereGeometry.ts
@@ -1,0 +1,94 @@
+import * as THREE from 'three'
+import { onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef, WatchStopHandle } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { Disposable } from '../../types/common'
+
+export interface UseSphereGeometryOptions {
+  radius?: number
+  widthSegments?: number
+  heightSegments?: number
+  phiStart?: number
+  phiLength?: number
+  thetaStart?: number
+  thetaLength?: number
+}
+
+export interface UseSphereGeometryResult {
+  geometry: ShallowRef<THREE.SphereGeometry | null>
+  dispose: Disposable
+}
+
+function createGeometry(options: UseSphereGeometryOptions): THREE.SphereGeometry {
+  const {
+    radius = 1,
+    widthSegments = 32,
+    heightSegments = 16,
+    phiStart = 0,
+    phiLength = Math.PI * 2,
+    thetaStart = 0,
+    thetaLength = Math.PI,
+  } = options
+
+  return new THREE.SphereGeometry(
+    radius,
+    widthSegments,
+    heightSegments,
+    phiStart,
+    phiLength,
+    thetaStart,
+    thetaLength,
+  )
+}
+
+/**
+ * Lazily instantiate a `THREE.SphereGeometry` that reacts to option updates while disposing previous instances.
+ */
+export function useSphereGeometry(options?: MaybeRefOrGetter<UseSphereGeometryOptions | undefined>): UseSphereGeometryResult {
+  const geometry: ShallowRef<THREE.SphereGeometry | null> = shallowRef(null)
+  let stop: WatchStopHandle | null = null
+
+  const dispose: Disposable = () => {
+    stop?.()
+    stop = null
+    if (geometry.value) {
+      geometry.value.dispose()
+      geometry.value = null
+    }
+  }
+
+  const apply = (next: UseSphereGeometryOptions | undefined) => {
+    const resolved = next ?? {}
+    const fresh = createGeometry(resolved)
+    const previous = geometry.value
+    geometry.value = fresh
+    previous?.dispose()
+  }
+
+  if (options) {
+    let lastSignature = ''
+    stop = watch(
+      () => {
+        const value = toValue(options) ?? {}
+        return `${value.radius ?? 1}|${value.widthSegments ?? 32}|${value.heightSegments ?? 16}|${value.phiStart ?? 0}|${value.phiLength ?? Math.PI * 2}|${value.thetaStart ?? 0}|${value.thetaLength ?? Math.PI}`
+      },
+      (signature) => {
+        if (signature === lastSignature)
+          return
+        lastSignature = signature
+        const resolved = toValue(options) ?? {}
+        apply(resolved)
+      },
+      { immediate: true },
+    )
+  }
+  else {
+    apply(undefined)
+  }
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return { geometry, dispose }
+}

--- a/src/composables/light/useDirectionalLight.ts
+++ b/src/composables/light/useDirectionalLight.ts
@@ -1,0 +1,101 @@
+import * as THREE from 'three'
+import { onBeforeUnmount, shallowRef, watchEffect } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { ColorLike, Disposable, Vec3 } from '../../types/common'
+import { useScene } from '../geom/useScene'
+
+export interface UseDirectionalLightOptions {
+  color?: ColorLike
+  intensity?: number
+  position?: Vec3
+  target?: Vec3
+  castShadow?: boolean
+}
+
+export interface UseDirectionalLightResult {
+  light: ShallowRef<THREE.DirectionalLight | null>
+  dispose: Disposable
+}
+
+function applyVector(target: THREE.Vector3, tuple?: Vec3) {
+  if (!tuple)
+    return
+  target.set(tuple[0], tuple[1], tuple[2])
+}
+
+/**
+ * Create and register a `THREE.DirectionalLight` inside the active scene.
+ */
+export function useDirectionalLight(options?: MaybeRefOrGetter<UseDirectionalLightOptions | undefined>): UseDirectionalLightResult {
+  const { scene } = useScene()
+  const light: ShallowRef<THREE.DirectionalLight | null> = shallowRef(null)
+  const targetHelper = new THREE.Object3D()
+
+  const dispose: Disposable = () => {
+    if (!light.value)
+      return
+
+    const currentScene = scene.value
+    if (currentScene) {
+      currentScene.remove(light.value)
+      currentScene.remove(light.value.target)
+    }
+
+    light.value.dispose()
+    light.value = null
+  }
+
+  watchEffect((onCleanup) => {
+    const currentScene = scene.value
+    if (!currentScene)
+      return
+
+    if (!light.value) {
+      const resolved = options ? toValue(options) ?? {} : {}
+      light.value = new THREE.DirectionalLight(resolved.color ?? 0xffffff, resolved.intensity ?? 1)
+      applyVector(light.value.position, resolved.position ?? [3, 3, 3])
+      applyVector(targetHelper.position, resolved.target ?? [0, 0, 0])
+      light.value.target = targetHelper
+      light.value.castShadow = resolved.castShadow ?? false
+      currentScene.add(light.value)
+      currentScene.add(light.value.target)
+    }
+
+    const instance = light.value
+    if (!instance)
+      return
+
+    currentScene.add(instance)
+    currentScene.add(instance.target)
+
+    onCleanup(() => {
+      currentScene.remove(instance)
+      currentScene.remove(instance.target)
+    })
+  })
+
+  watchEffect(() => {
+    if (!light.value)
+      return
+
+    const next = options ? toValue(options) ?? {} : {}
+
+    if (next.color !== undefined)
+      light.value.color.set(next.color)
+    if (typeof next.intensity === 'number')
+      light.value.intensity = Math.max(0, next.intensity)
+    if (next.position)
+      applyVector(light.value.position, next.position)
+    if (next.target)
+      applyVector(light.value.target.position, next.target)
+    if (typeof next.castShadow === 'boolean')
+      light.value.castShadow = next.castShadow
+  })
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return { light, dispose }
+}

--- a/src/composables/load/useEnvMap.ts
+++ b/src/composables/load/useEnvMap.ts
@@ -1,0 +1,189 @@
+import * as THREE from 'three'
+import { computed, onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef, ComputedRef } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { Disposable } from '../../types/common'
+import { useVhree } from '../core/useVhree'
+
+const isClient = typeof window !== 'undefined'
+
+export type EnvMapSource =
+  | string
+  | { type: 'rgbe'; url: string }
+  | { type: 'equirect'; url: string }
+  | { type: 'cube'; urls: readonly [string, string, string, string, string, string] }
+
+export interface UseEnvMapOptions {
+  colorSpace?: THREE.ColorSpace
+  usePmrem?: boolean
+}
+
+export interface UseEnvMapResult {
+  envMap: ShallowRef<THREE.Texture | null>
+  isLoading: ComputedRef<boolean>
+  error: ShallowRef<Error | null>
+  dispose: Disposable
+  reload: () => Promise<void>
+}
+
+function inferSourceType(source: string): EnvMapSource {
+  const lower = source.toLowerCase()
+  if (lower.endsWith('.hdr') || lower.endsWith('.exr'))
+    return { type: 'rgbe', url: source }
+  return { type: 'equirect', url: source }
+}
+
+async function loadRgbE(url: string): Promise<THREE.DataTexture> {
+  const { RGBELoader } = await import('three/examples/jsm/loaders/RGBELoader')
+  const loader = new RGBELoader()
+  return loader.loadAsync(url)
+}
+
+function applyEnvMapOptions(texture: THREE.Texture, options: UseEnvMapOptions | undefined) {
+  if (!options)
+    return
+  if (options.colorSpace)
+    texture.colorSpace = options.colorSpace
+  texture.needsUpdate = true
+}
+
+export function useEnvMap(source: MaybeRefOrGetter<EnvMapSource | null | undefined>, options?: MaybeRefOrGetter<UseEnvMapOptions | undefined>): UseEnvMapResult {
+  const { context } = useVhree()
+  const envMap: ShallowRef<THREE.Texture | null> = shallowRef(null)
+  const error = shallowRef<Error | null>(null)
+  const loading = shallowRef(false)
+  let token = 0
+
+  const dispose: Disposable = () => {
+    token += 1
+    envMap.value?.dispose()
+    envMap.value = null
+    error.value = null
+    loading.value = false
+  }
+
+  const convertWithPmrem = (texture: THREE.Texture, type: 'equirect' | 'rgbe' | 'cube'): THREE.Texture => {
+    const renderer = context.value?.renderer.value
+    const shouldPmrem = options ? (toValue(options)?.usePmrem ?? true) : true
+    if (!renderer || !shouldPmrem)
+      return texture
+
+    const generator = new THREE.PMREMGenerator(renderer)
+    generator.compileEquirectangularShader()
+
+    try {
+      let target: THREE.WebGLRenderTarget
+      if (type === 'cube')
+        target = generator.fromCubemap(texture as THREE.CubeTexture)
+      else
+        target = generator.fromEquirectangular(texture)
+      texture.dispose()
+      const result = target.texture
+      generator.dispose()
+      return result
+    }
+    catch (err) {
+      generator.dispose()
+      throw err
+    }
+  }
+
+  const loadTextureByKind = async (source: Exclude<EnvMapSource, string>): Promise<THREE.Texture> => {
+    if (!isClient)
+      return new THREE.Texture()
+
+    if (source.type === 'cube') {
+      const loader = new THREE.CubeTextureLoader()
+      const cube = await loader.loadAsync(source.urls)
+      cube.mapping = THREE.CubeReflectionMapping
+      return convertWithPmrem(cube, 'cube')
+    }
+
+    if (source.type === 'rgbe') {
+      const hdr = await loadRgbE(source.url)
+      hdr.mapping = THREE.EquirectangularReflectionMapping
+      hdr.needsUpdate = true
+      return convertWithPmrem(hdr, 'rgbe')
+    }
+
+    const loader = new THREE.TextureLoader()
+    const texture = await loader.loadAsync(source.url)
+    texture.mapping = THREE.EquirectangularReflectionMapping
+    texture.needsUpdate = true
+    return convertWithPmrem(texture, 'equirect')
+  }
+
+  const load = async (input: EnvMapSource) => {
+    if (!isClient)
+      return
+
+    const current = ++token
+    loading.value = true
+    error.value = null
+
+    try {
+      const texture = await (typeof input === 'string' ? loadTextureByKind(inferSourceType(input)) : loadTextureByKind(input))
+
+      if (current !== token) {
+        texture.dispose()
+        return
+      }
+
+      applyEnvMapOptions(texture, options ? toValue(options) : undefined)
+      const previous = envMap.value
+      envMap.value = texture
+      previous?.dispose()
+    }
+    catch (err) {
+      if (current === token)
+        error.value = err instanceof Error ? err : new Error(String(err))
+    }
+    finally {
+      if (current === token)
+        loading.value = false
+    }
+  }
+
+  const reload = async () => {
+    const raw = toValue(source)
+    if (!raw) {
+      dispose()
+      return
+    }
+    await load(raw)
+  }
+
+  watch(
+    () => toValue(source),
+    (value) => {
+      if (!value) {
+        dispose()
+        return
+      }
+      reload()
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => (options ? toValue(options) : undefined),
+    (next) => {
+      if (!envMap.value || !next)
+        return
+      applyEnvMapOptions(envMap.value, next)
+    },
+    { deep: true },
+  )
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return {
+    envMap,
+    isLoading: computed(() => loading.value),
+    error,
+    dispose,
+    reload,
+  }
+}

--- a/src/composables/load/useGLTF.ts
+++ b/src/composables/load/useGLTF.ts
@@ -1,0 +1,226 @@
+import * as THREE from 'three'
+import { computed, onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef, ComputedRef } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import type { Disposable } from '../../types/common'
+import { useVhree } from '../core/useVhree'
+
+const isClient = typeof window !== 'undefined'
+
+export interface UseGLTFOptions {
+  crossOrigin?: string
+  dracoDecoderPath?: string
+  ktx2TranscoderPath?: string
+  meshoptDecoder?: () => Promise<any>
+  onModifyLoader?: (loader: GLTFLoader) => void
+}
+
+export interface UseGLTFResult {
+  gltf: ShallowRef<GLTF | null>
+  scene: ComputedRef<THREE.Object3D | null>
+  isLoading: ComputedRef<boolean>
+  error: ShallowRef<Error | null>
+  dispose: Disposable
+  reload: () => Promise<void>
+}
+
+async function createLoader(options: UseGLTFOptions | undefined, renderer: THREE.WebGLRenderer | null): Promise<{ loader: GLTFLoader; dispose: Disposable }> {
+  const { GLTFLoader: LoaderCtor } = await import('three/examples/jsm/loaders/GLTFLoader')
+  const loader = new LoaderCtor()
+  const disposers: Disposable[] = []
+
+  if (options?.crossOrigin)
+    loader.setCrossOrigin(options.crossOrigin)
+
+  if (options?.dracoDecoderPath) {
+    const { DRACOLoader } = await import('three/examples/jsm/loaders/DRACOLoader')
+    const dracoLoader = new DRACOLoader()
+    dracoLoader.setDecoderPath(options.dracoDecoderPath)
+    loader.setDRACOLoader(dracoLoader)
+    disposers.push(() => dracoLoader.dispose())
+  }
+
+  if (options?.ktx2TranscoderPath) {
+    const { KTX2Loader } = await import('three/examples/jsm/loaders/KTX2Loader')
+    const ktxLoader = new KTX2Loader()
+    ktxLoader.setTranscoderPath(options.ktx2TranscoderPath)
+    if (renderer)
+      ktxLoader.detectSupport(renderer)
+    loader.setKTX2Loader(ktxLoader)
+    disposers.push(() => ktxLoader.dispose())
+  }
+
+  if (options?.meshoptDecoder) {
+    const decoder = await options.meshoptDecoder()
+    loader.setMeshoptDecoder(decoder)
+  }
+
+  options?.onModifyLoader?.(loader)
+
+  return { loader, dispose: () => disposers.forEach((fn) => fn()) }
+}
+
+function disposeGLTF(gltf: GLTF | null) {
+  if (!gltf)
+    return
+
+  const materials = new Set<THREE.Material>()
+
+  const disposeMaterial = (material: THREE.Material | THREE.Material[] | undefined) => {
+    if (!material)
+      return
+    if (Array.isArray(material)) {
+      material.forEach((mat) => disposeMaterial(mat))
+      return
+    }
+    if (materials.has(material))
+      return
+    material.dispose?.()
+    materials.add(material)
+  }
+
+  const disposeTexture = (texture: THREE.Texture | undefined) => {
+    texture?.dispose?.()
+  }
+
+  gltf.scenes?.forEach((scene) => {
+    scene.traverse((child) => {
+      const mesh = child as THREE.Mesh
+      if (mesh.isMesh || mesh.isSkinnedMesh) {
+        disposeMaterial(mesh.material as THREE.Material | THREE.Material[])
+        mesh.geometry?.dispose?.()
+      }
+      const points = child as THREE.Points
+      if (points.isPoints) {
+        disposeMaterial(points.material as THREE.Material | THREE.Material[])
+        points.geometry?.dispose?.()
+      }
+      const line = child as THREE.Line
+      if (line.isLine || line.isLineSegments) {
+        disposeMaterial(line.material as THREE.Material | THREE.Material[])
+        line.geometry?.dispose?.()
+      }
+    })
+  })
+
+  void gltf.parser?.getDependencies?.('texture').then((textures) => {
+    textures?.forEach((tex) => disposeTexture(tex))
+  }).catch(() => {})
+
+  gltf.parser?.dispose?.()
+}
+
+export function useGLTF(source: MaybeRefOrGetter<string | null | undefined>, options?: MaybeRefOrGetter<UseGLTFOptions | undefined>): UseGLTFResult {
+  const { context } = useVhree()
+  const gltf: ShallowRef<GLTF | null> = shallowRef(null)
+  const error = shallowRef<Error | null>(null)
+  const loading = shallowRef(false)
+  let token = 0
+
+  const dispose: Disposable = () => {
+    token += 1
+    disposeGLTF(gltf.value)
+    gltf.value = null
+    error.value = null
+    loading.value = false
+  }
+
+  const load = async (url: string) => {
+    if (!isClient)
+      return
+
+    const targetUrl = url.trim()
+    if (!targetUrl) {
+      dispose()
+      return
+    }
+
+    const current = ++token
+    loading.value = true
+    error.value = null
+
+    let disposeExtras: Disposable | null = null
+    try {
+      const opts = options ? toValue(options) : undefined
+      const created = await createLoader(opts, context.value?.renderer.value ?? null)
+      const loader = created.loader
+      disposeExtras = created.dispose
+      const model = await loader.loadAsync(targetUrl)
+
+      if (current !== token) {
+        disposeGLTF(model)
+        return
+      }
+
+      disposeGLTF(gltf.value)
+      gltf.value = model
+    }
+    catch (err) {
+      if (current === token) {
+        const errorMessage = err instanceof Error ? err.message : String(err)
+        const failure = new Error(`Failed to load GLTF from "${targetUrl}": ${errorMessage}`)
+        if (err instanceof Error) {
+          try {
+            Object.defineProperty(failure, 'cause', { value: err })
+          }
+          catch {
+            // ignore environments that do not allow redefining the property
+          }
+        }
+        error.value = failure
+      }
+    }
+    finally {
+      disposeExtras?.()
+      if (current === token)
+        loading.value = false
+    }
+  }
+
+  const reload = async () => {
+    const rawUrl = toValue(source)
+    const normalizedUrl = typeof rawUrl === 'string' ? rawUrl.trim() : ''
+    if (!normalizedUrl) {
+      dispose()
+      return
+    }
+    await load(normalizedUrl)
+  }
+
+  watch(
+    () => toValue(source),
+    (url) => {
+      const resolvedUrl = typeof url === 'string' ? url.trim() : ''
+      if (!resolvedUrl) {
+        dispose()
+        return
+      }
+      void load(resolvedUrl)
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => (options ? toValue(options) : undefined),
+    () => {
+      if (!gltf.value)
+        return
+      reload()
+    },
+    { deep: true },
+  )
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return {
+    gltf,
+    scene: computed(() => gltf.value?.scene ?? null),
+    isLoading: computed(() => loading.value),
+    error,
+    dispose,
+    reload,
+  }
+}

--- a/src/composables/load/useTexture.ts
+++ b/src/composables/load/useTexture.ts
@@ -1,0 +1,145 @@
+import * as THREE from 'three'
+import { computed, onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef, ComputedRef } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { Disposable } from '../../types/common'
+
+const isClient = typeof window !== 'undefined'
+
+export interface UseTextureOptions {
+  crossOrigin?: string
+  colorSpace?: THREE.ColorSpace
+  generateMipmaps?: boolean
+  minFilter?: THREE.TextureFilter
+  magFilter?: THREE.TextureFilter
+  wrapS?: THREE.Wrapping
+  wrapT?: THREE.Wrapping
+  anisotropy?: number
+  flipY?: boolean
+}
+
+export interface UseTextureResult {
+  texture: ShallowRef<THREE.Texture | null>
+  isLoading: ComputedRef<boolean>
+  error: ShallowRef<Error | null>
+  dispose: Disposable
+  reload: () => Promise<void>
+}
+
+function applyTextureOptions(texture: THREE.Texture, options: UseTextureOptions | undefined) {
+  if (!options)
+    return
+
+  if (options.colorSpace)
+    texture.colorSpace = options.colorSpace
+  if (typeof options.generateMipmaps === 'boolean')
+    texture.generateMipmaps = options.generateMipmaps
+  if (typeof options.flipY === 'boolean')
+    texture.flipY = options.flipY
+  if (typeof options.anisotropy === 'number')
+    texture.anisotropy = options.anisotropy
+  if (options.minFilter)
+    texture.minFilter = options.minFilter
+  if (options.magFilter)
+    texture.magFilter = options.magFilter
+  if (options.wrapS)
+    texture.wrapS = options.wrapS
+  if (options.wrapT)
+    texture.wrapT = options.wrapT
+  texture.needsUpdate = true
+}
+
+export function useTexture(source: MaybeRefOrGetter<string | null | undefined>, options?: MaybeRefOrGetter<UseTextureOptions | undefined>): UseTextureResult {
+  const texture: ShallowRef<THREE.Texture | null> = shallowRef(null)
+  const error = shallowRef<Error | null>(null)
+  const loading = shallowRef(false)
+  let token = 0
+
+  const dispose: Disposable = () => {
+    token += 1
+    texture.value?.dispose()
+    texture.value = null
+    error.value = null
+    loading.value = false
+  }
+
+  const loadFromUrl = async (url: string) => {
+    if (!isClient)
+      return
+
+    const current = ++token
+    loading.value = true
+    error.value = null
+
+    const loader = new THREE.TextureLoader()
+    if (options) {
+      const resolved = toValue(options)
+      if (resolved?.crossOrigin)
+        loader.setCrossOrigin(resolved.crossOrigin)
+    }
+
+    try {
+      const tex = await loader.loadAsync(url)
+      if (current !== token) {
+        tex.dispose()
+        return
+      }
+
+      applyTextureOptions(tex, options ? toValue(options) : undefined)
+      const previous = texture.value
+      texture.value = tex
+      previous?.dispose()
+    }
+    catch (err) {
+      if (current === token)
+        error.value = err instanceof Error ? err : new Error(String(err))
+    }
+    finally {
+      if (current === token)
+        loading.value = false
+    }
+  }
+
+  const reload = async () => {
+    const url = toValue(source)
+    if (!url) {
+      dispose()
+      return
+    }
+    await loadFromUrl(url)
+  }
+
+  watch(
+    () => toValue(source),
+    (url) => {
+      if (!url) {
+        dispose()
+        return
+      }
+      reload()
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => (options ? toValue(options) : undefined),
+    (next) => {
+      if (!texture.value || !next)
+        return
+      applyTextureOptions(texture.value, next)
+    },
+    { deep: true },
+  )
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return {
+    texture,
+    isLoading: computed(() => loading.value),
+    error,
+    dispose,
+    reload,
+  }
+}

--- a/src/composables/mat/useStandardMaterial.ts
+++ b/src/composables/mat/useStandardMaterial.ts
@@ -1,0 +1,66 @@
+import * as THREE from 'three'
+import { onBeforeUnmount, shallowRef, watchEffect } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import { toValue } from '@vueuse/core'
+import type { ColorLike, Disposable } from '../../types/common'
+
+export interface UseStandardMaterialOptions {
+  color?: ColorLike
+  roughness?: number
+  metalness?: number
+  emissive?: ColorLike
+  envMap?: THREE.Texture | null
+  map?: THREE.Texture | null
+}
+
+export interface UseStandardMaterialResult {
+  material: ShallowRef<THREE.MeshStandardMaterial | null>
+  dispose: Disposable
+}
+
+function ensureMaterial(ref: ShallowRef<THREE.MeshStandardMaterial | null>): THREE.MeshStandardMaterial {
+  if (!ref.value)
+    ref.value = new THREE.MeshStandardMaterial({ color: '#ffffff' })
+  return ref.value
+}
+
+/**
+ * Create a `MeshStandardMaterial` that updates in place when the provided options change.
+ */
+export function useStandardMaterial(options?: MaybeRefOrGetter<UseStandardMaterialOptions | undefined>): UseStandardMaterialResult {
+  const material: ShallowRef<THREE.MeshStandardMaterial | null> = shallowRef(null)
+
+  const dispose: Disposable = () => {
+    if (material.value) {
+      material.value.dispose()
+      material.value = null
+    }
+  }
+
+  watchEffect(() => {
+    const next = options ? toValue(options) ?? {} : {}
+    const instance = ensureMaterial(material)
+
+    if (next.color !== undefined)
+      instance.color.set(next.color)
+    if (next.emissive !== undefined)
+      instance.emissive.set(next.emissive)
+    if (typeof next.roughness === 'number')
+      instance.roughness = THREE.MathUtils.clamp(next.roughness, 0, 1)
+    if (typeof next.metalness === 'number')
+      instance.metalness = THREE.MathUtils.clamp(next.metalness, 0, 1)
+
+    if (next.map !== undefined)
+      instance.map = next.map ?? null
+    if (next.envMap !== undefined) {
+      instance.envMap = next.envMap ?? null
+      instance.needsUpdate = true
+    }
+  })
+
+  onBeforeUnmount(() => {
+    dispose()
+  })
+
+  return { material, dispose }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,22 @@ export { default as Vhree } from './components/Vhree.vue'
 export { default as VMesh } from './components/VMesh.vue'
 
 export { useFrame } from './composables/useFrame'
+export { useVhree } from './composables/core/useVhree'
+export { useRenderLoop } from './composables/core/useRenderLoop'
+export { useCamera } from './composables/core/useCamera'
+
+export { useScene } from './composables/geom/useScene'
+export { useBoxGeometry } from './composables/geom/useBoxGeometry'
+export { useSphereGeometry } from './composables/geom/useSphereGeometry'
+
+export { useStandardMaterial } from './composables/mat/useStandardMaterial'
+
+export { useDirectionalLight } from './composables/light/useDirectionalLight'
+
+export { useOrbitControls } from './composables/controls/useOrbitControls'
+
+export { useTexture } from './composables/load/useTexture'
+export { useEnvMap } from './composables/load/useEnvMap'
+export { useGLTF } from './composables/load/useGLTF'
+
+export type { Vec3, EulerTuple, ColorLike, Disposable } from './types/common'

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,21 @@
+import type { ColorRepresentation, EulerOrder } from 'three'
+
+/**
+ * Immutable tuple describing a 3D vector. Values follow the `[x, y, z]` order.
+ */
+export type Vec3 = readonly [number, number, number]
+
+/**
+ * Tuple describing Euler rotation in radians. Optional fourth slot allows specifying the rotation order.
+ */
+export type EulerTuple = readonly [number, number, number, EulerOrder?]
+
+/**
+ * Supported colour representations accepted by vhree.js composables and components.
+ */
+export type ColorLike = ColorRepresentation
+
+/**
+ * Function signature for explicit cleanup handlers returned by composables.
+ */
+export type Disposable = () => void

--- a/stories/composables/ResourceHooks.story.vue
+++ b/stories/composables/ResourceHooks.story.vue
@@ -1,0 +1,200 @@
+<script lang="ts" setup>
+import * as THREE from 'three'
+import { computed, reactive, watchEffect } from 'vue'
+import { VCamera, VMesh, Vhree, useBoxGeometry, useDirectionalLight, useEnvMap, useGLTF, useOrbitControls, useScene, useStandardMaterial, useTexture } from '../../src'
+
+const SAMPLE_GLTF_URL = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Triangle/glTF/Triangle.gltf'
+const BROKEN_GLTF_URL = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/NonExistent/glTF/model.gltf'
+const SAMPLE_TEXTURE_URL = 'https://threejs.org/examples/textures/uv_grid_opengl.jpg'
+const SAMPLE_ENV_URL = 'https://threejs.org/examples/textures/equirectangular/venice_sunset_1k.hdr'
+
+const state = reactive({
+  textureSource: SAMPLE_TEXTURE_URL,
+  envSource: SAMPLE_ENV_URL,
+  gltfSource: SAMPLE_GLTF_URL,
+  baseColor: '#f97316',
+  lightColor: '#facc15',
+  lightIntensity: 1.6,
+  lightX: 2,
+  lightY: 3,
+  lightZ: 4,
+  boxWidth: 1.2,
+  boxHeight: 0.8,
+  boxDepth: 1.2,
+  autoRotate: true,
+})
+
+const textureSource = computed(() => state.textureSource)
+const envSource = computed(() => state.envSource)
+const gltfSource = computed(() => state.gltfSource)
+
+const { texture, isLoading: textureLoading, error: textureError, reload: reloadTexture } = useTexture(textureSource, {
+  colorSpace: THREE.SRGBColorSpace,
+  minFilter: THREE.LinearMipmapLinearFilter,
+  magFilter: THREE.LinearFilter,
+  generateMipmaps: true,
+})
+
+const { envMap, isLoading: envLoading, error: envError, reload: reloadEnv } = useEnvMap(envSource, {
+  colorSpace: THREE.SRGBColorSpace,
+  usePmrem: true,
+})
+
+const { geometry } = useBoxGeometry(() => ({
+  width: state.boxWidth,
+  height: state.boxHeight,
+  depth: state.boxDepth,
+}))
+
+const { material } = useStandardMaterial(() => ({
+  color: state.baseColor,
+  map: texture.value,
+  envMap: envMap.value,
+  metalness: 0.2,
+  roughness: 0.45,
+}))
+
+const meshGeometry = computed(() => geometry.value ?? undefined)
+const meshMaterial = computed(() => material.value ?? undefined)
+
+const { light } = useDirectionalLight(() => ({
+  color: state.lightColor,
+  intensity: state.lightIntensity,
+  position: [state.lightX, state.lightY, state.lightZ] as const,
+}))
+
+watchEffect(() => {
+  if (!light.value)
+    return
+  light.value.castShadow = true
+})
+
+const { controls } = useOrbitControls(() => ({
+  enableDamping: true,
+  dampingFactor: 0.12,
+  autoRotate: state.autoRotate,
+  autoRotateSpeed: 1.2,
+  target: [0, 0, 0] as const,
+}))
+
+watchEffect(() => {
+  controls.value
+})
+
+const { gltf, isLoading: gltfLoading, error: gltfError, reload: reloadGltf } = useGLTF(gltfSource)
+const { scene } = useScene()
+
+watchEffect((onCleanup) => {
+  const targetScene = scene.value
+  const model = gltf.value?.scene ?? null
+  if (!targetScene || !model)
+    return
+
+  model.position.set(0, -0.1, 0)
+  targetScene.add(model)
+
+  onCleanup(() => {
+    targetScene.remove(model)
+  })
+})
+</script>
+
+<template>
+  <Story title="Resource composables" auto-props-disabled>
+    <template #controls>
+      <div class="control-grid">
+        <HstColor v-model="state.baseColor" title="Base colour" />
+        <HstColor v-model="state.lightColor" title="Light colour" />
+        <HstSlider v-model="state.lightIntensity" title="Light intensity" :min="0" :max="5" :step="0.1" />
+        <HstSlider v-model="state.boxWidth" title="Box width" :min="0.2" :max="2" :step="0.1" />
+        <HstSlider v-model="state.boxHeight" title="Box height" :min="0.2" :max="2" :step="0.1" />
+        <HstSlider v-model="state.boxDepth" title="Box depth" :min="0.2" :max="2" :step="0.1" />
+        <HstToggle v-model="state.autoRotate" title="Orbit auto rotate" />
+        <div class="control-row">
+          <HstButton @click="reloadTexture">Reload texture</HstButton>
+          <small v-if="textureLoading">Loading…</small>
+          <small v-else-if="textureError" class="error">Failed</small>
+        </div>
+        <HstInput v-model="state.textureSource" title="Texture URL" placeholder="https://…" />
+        <div class="control-row">
+          <HstButton @click="state.textureSource = SAMPLE_TEXTURE_URL">Use sample texture</HstButton>
+        </div>
+        <div class="control-row">
+          <HstButton @click="reloadEnv">Reload env map</HstButton>
+          <small v-if="envLoading">Loading…</small>
+          <small v-else-if="envError" class="error">Failed</small>
+        </div>
+        <HstInput v-model="state.envSource" title="Env map URL" placeholder="https://…" />
+        <div class="control-row">
+          <HstButton @click="state.envSource = SAMPLE_ENV_URL">Use sample env map</HstButton>
+        </div>
+        <div class="control-row">
+          <HstButton @click="reloadGltf">Reload GLTF</HstButton>
+          <small v-if="gltfLoading">Loading…</small>
+          <small v-else-if="gltfError" class="error">{{ gltfError.message }}</small>
+        </div>
+        <HstInput v-model="state.gltfSource" title="GLTF URL" placeholder="https://…" />
+        <div class="control-row">
+          <HstButton @click="state.gltfSource = SAMPLE_GLTF_URL">Use sample GLTF</HstButton>
+          <HstButton @click="state.gltfSource = BROKEN_GLTF_URL">Load missing GLTF</HstButton>
+        </div>
+      </div>
+    </template>
+
+    <Variant title="Textured box">
+      <div class="story-canvas">
+        <Vhree :background="'#0f172a'">
+          <VCamera :position="[0, 0.8, 3.2]" :look-at="[0, 0, 0]" />
+          <VMesh :geometry="meshGeometry" :material="meshMaterial" />
+        </Vhree>
+      </div>
+      <template #description>
+        `useTexture`, `useEnvMap`, `useBoxGeometry`, and `useStandardMaterial` build a textured mesh while `useDirectionalLight` and `useOrbitControls` keep lighting and interaction in sync.
+      </template>
+    </Variant>
+
+    <Variant title="GLTF injection">
+      <div class="story-canvas">
+        <Vhree :background="'#0b1120'">
+          <VCamera :position="[0, 0.6, 2.2]" :look-at="[0, 0, 0]" />
+        </Vhree>
+      </div>
+      <template #description>
+        The triangle GLTF is fetched from the Khronos sample repository with `useGLTF` and attached to the shared scene with `useScene`.
+        Try the controls to point the loader at an invalid URL and inspect the surfaced error message.
+      </template>
+    </Variant>
+  </Story>
+</template>
+
+<style scoped>
+.story-canvas {
+  flex: 1;
+  min-height: 320px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: #020617;
+  border: 1px solid #1f2937;
+}
+
+.story-canvas :deep(canvas) {
+  border-radius: 0.75rem;
+}
+
+.control-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  color: #e2e8f0;
+}
+
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.error {
+  color: #f87171;
+}
+</style>


### PR DESCRIPTION
## Summary
- remove the bundled texture assets that previously shipped in `public/textures`
- update the README and composable reference to point texture examples at remote sample URLs
- refresh the resource composable story to default to remote texture and env-map sources while keeping the GLTF error demo

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68de762bc5fc832a8bc65ba2acf04a8a